### PR TITLE
Refactor: Update onError lambda in MovieTrendingFragment

### DIFF
--- a/app/src/main/java/com/taufik/themovieshow/ui/movie/fragment/MovieTrendingFragment.kt
+++ b/app/src/main/java/com/taufik/themovieshow/ui/movie/fragment/MovieTrendingFragment.kt
@@ -73,9 +73,9 @@ class MovieTrendingFragment : BaseFragment<FragmentMovieTvShowsListBinding>() {
                     )
                     movieTrendingAdapter?.submitList(filteredAndSortedMovies)
                 },
-                onError = {
+                onError = { message ->
                     pbLoading.hideView()
-                    layoutError.showError(it)
+                    layoutError.showError(message)
                 }
             )
         }


### PR DESCRIPTION
- The `onError` lambda in `MovieTrendingFragment.kt` now accepts a `message` parameter.
- The `showError` method is now called with the `message` parameter instead of `it`.