### PR TITLE
core/migrate-to-flow

### DIFF
--- a/app/src/main/java/com/taufik/themovieshow/ui/movie/fragment/MovieUpcomingFragment.kt
+++ b/app/src/main/java/com/taufik/themovieshow/ui/movie/fragment/MovieUpcomingFragment.kt
@@ -72,9 +72,9 @@ class MovieUpcomingFragment : BaseFragment<FragmentMovieTvShowsListBinding>() {
                     )
                     movieAdapter?.submitList(filteredAndSortedMovies)
                 },
-                onError = {
+                onError = { message ->
                     pbLoading.hideView()
-                    layoutError.showError(it)
+                    layoutError.showError(message)
                 }
             )
         }


### PR DESCRIPTION
Refactor: Rename lambda parameter in MovieUpcomingFragment
- In `MovieUpcomingFragment.kt`, the implicit `it` parameter in the `onError` lambda has been explicitly named `message` for improved clarity.